### PR TITLE
ADAPT-966 - Record generic component completion statements

### DIFF
--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -85,7 +85,7 @@ define(function(require) {
         activityId: this.get('activityId'),
         actor: this.get('actor'),
         registration: this.get('registration'),
-        componentState: component
+        model: component
       }).getStatementObject();
 
       if (!statement) {

--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -81,16 +81,18 @@ define(function(require) {
     },
 
     onComponentComplete: function(component) {
-      var statement = new ComponentStatementModel({
+      var statementModel = new ComponentStatementModel({
         activityId: this.get('activityId'),
         actor: this.get('actor'),
         registration: this.get('registration'),
         model: component
-      }).getStatementObject();
+      });
 
-      if (!statement) {
+      if (!statementModel) {
         return;
       }
+
+      var statement = statementModel.getStatementObject();
 
       this.sendStatement(
         statement
@@ -130,16 +132,18 @@ define(function(require) {
     },
 
     onAssessmentComplete: function(assessment) {
-      var statement = new AssessmentStatementModel({
+      var statementModel = new AssessmentStatementModel({
         activityId: this.get('activityId'),
         actor: this.get('actor'),
-        assessmentState: assessment,
+        model: assessment,
         registration: this.get('registration')
-      }).getStatementObject();
+      });
 
-      if (!statement) {
+      if (!statementModel) {
         return;
       }
+
+      var statement = statementModel.getStatementObject();
 
       this.sendStatement(
         statement

--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -12,6 +12,7 @@ define(function(require) {
   var _ = require('underscore');
   var xapi = require('./xapiwrapper.min');
   var AssessmentStatementModel = require('./models/assessment-statement');
+  var ComponentStatementModel = require('./models/component-statement');
 
   var xapiWrapper;
   var STATE_PROGRESS = 'adapt-course-progress';
@@ -70,12 +71,30 @@ define(function(require) {
     },
 
     setupListeners: function() {
+      this.listenTo(Adapt.components, "change:_isComplete", this.onComponentComplete);
       this.listenTo(Adapt.blocks, "change:_isComplete", this.onBlockComplete);
       this.listenTo(Adapt.course, "change:_isComplete", this.onCourseComplete);
       this.listenTo(Adapt, "assessments:complete", this.onAssessmentComplete);
       this.listenTo(Adapt, "assessment:complete", this.onAllAssessmentsComplete);
       this.listenTo(Adapt, "xapi:stateChanged", this.onStateChanged);
       this.listenTo(Adapt, "xapi:stateLoaded", this.restoreState);
+    },
+
+    onComponentComplete: function(component) {
+      var statement = new ComponentStatementModel({
+        activityId: this.get('activityId'),
+        actor: this.get('actor'),
+        registration: this.get('registration'),
+        componentState: component
+      }).getStatementObject();
+
+      if (!statement) {
+        return;
+      }
+
+      this.sendStatement(
+        statement
+      );
     },
 
     onBlockComplete: function(block) {

--- a/js/models/assessment-statement.js
+++ b/js/models/assessment-statement.js
@@ -1,81 +1,47 @@
 define(function(require) {
 
   var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
   var Backbone = require('backbone');
+  var StatementModel = require('./statement');
 
-  var AssessmentStatementModel = Backbone.Model.extend({
-
-    defaults: {
-      activityId: "",
-      actor: null,
-      assessmentState: null,
-      registration: null
-    },
+  var AssessmentStatementModel = StatementModel.extend({
 
     initialize: function() {
-      if (!this.get("activityId")) {
-        return null;
-      }
-
-      if (!this.get("actor")) {
-        return null;
-      }
-
-      if (!this.get("assessmentState")) {
-        return null;
-      }
-
-      if (!this.get("registration")) {
-        return null;
-      }
+      return StatementModel.prototype.initialize.call(this);
     },
 
     getStatementObject: function() {
-      var statement = {};
+      var statement = StatementModel.prototype.getStatementObject.call(this);
 
       var verb = this.getVerb();
       var object = this.getObject();
-      var result = this.getResult();
       var context = this.getContext();
+      var result = this.getResult();
 
-      if (!verb) {
-        console.log('Failed to generate statement for assessment: Could not generate \'verb\'');
+      if (
+        _.isEmpty(verb) ||
+        _.isEmpty(object) ||
+        _.isEmpty(context) ||
+        _.isEmpty(result)
+      ) {
         return null;
       }
 
       statement.verb = verb;
-
-      if (!this.get('actor')) {
-        console.log('Failed to generate statement for assessment: \'actor\' is missing or invalid');
-        return null;
-      }
-
-      statement.actor = this.get('actor');
-
-      if (!object || !object.id) {
-        console.log('Failed to generate statement for assessment: Could not generate \'object\'');
-        return null;
-      }
-
       statement.object = object;
-
-      if (result) {
-        statement.result = result;
-      }
-
-      if (context) {
-        statement.context = context;
-      }
+      statement.context = context;
+      statement.result = result;
 
       return statement;
     },
 
     getVerb: function() {
-      if (!this.get('assessmentState')) {
+      if (_.isEmpty(this.get('model')) || typeof this.get("model").isPass == "undefined") {
         return null;
       }
 
-      return (this.get('assessmentState').isPass == true) ? ADL.verbs.passed : ADL.verbs.failed;
+      return (this.get('model').isPass == true) ? ADL.verbs.passed : ADL.verbs.failed;
     },
 
     getObject: function() {
@@ -86,56 +52,35 @@ define(function(require) {
         return null;
       }
 
-      object.id = iri
+      object.id = iri;
 
       return object;
     },
 
     getContext: function() {
-      var context = {};
+      var context = StatementModel.prototype.getContext.call(this);
 
       var contextActivities = this.getContextActivities();
-
-      if (contextActivities) {
+      if (!_.isEmpty(contextActivities)) {
         context.contextActivities = contextActivities;
-      }
-
-      var language = Adapt.config.get('_defaultLanguage');
-
-      if (language) {
-        context.language = language
-      }
-
-      var registration = this.get("registration");
-      if (registration) {
-        context.registration = registration
       }
 
       return context;
     },
 
     getContextActivities: function() {
-      var contextActivities = {};
-
-      if (this.get('activityId')) {
-        contextActivities.parent = {
-          id: this.get('activityId'),
-          objectType: "Activity"
-        }
-      }
-
-      return contextActivities;
+      return StatementModel.prototype.getContextActivities.call(this);
     },
 
     getScore: function() {
       var score = {};
 
-      if (this.get('assessmentState').scoreAsPercent != null) {
-        score.scaled = this.get('assessmentState').scoreAsPercent / 100;
+      if (typeof this.get('model').scoreAsPercent != 'undefined') {
+        score.scaled = this.get('model').scoreAsPercent / 100;
       }
 
-      if (this.get('assessmentState').score != null) {
-        score.raw = this.get('assessmentState').score;
+      if (typeof this.get('model').score != 'undefined') {
+        score.raw = this.get('model').score;
       }
 
       return score;
@@ -149,23 +94,23 @@ define(function(require) {
         result.score = score;
       }
 
-      if (this.get('assessmentState').isPass != null) {
-        result.success = this.get('assessmentState').isPass;
+      if (this.get('model').isPass != null) {
+        result.success = this.get('model').isPass;
       }
 
-      if (this.get('assessmentState').isComplete != null) {
-        result.completion = this.get('assessmentState').isComplete;
+      if (this.get('model').isComplete != null) {
+        result.completion = this.get('model').isComplete;
       }
 
       return result != {} ? result : null;
     },
 
     getIri: function() {
-      if (!this.get('activityId') || !this.get('assessmentState').id) {
+      if (!this.get('activityId') || !this.get('model').id) {
         return null;
       }
 
-      return [this.get('activityId'), 'assessment', this.get('assessmentState').id].join('/');
+      return [this.get('activityId'), 'assessment', this.get('model').id].join('/');
     },
 
   });

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -1,6 +1,7 @@
 define(function(require) {
 
   var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
   var Backbone = require('backbone');
   var StatementModel = require('./statement');
 
@@ -11,7 +12,25 @@ define(function(require) {
     },
 
     getStatementObject: function() {
-      return StatementModel.prototype.getStatementObject.call(this);
+      var statement = StatementModel.prototype.getStatementObject.call(this);
+
+      var verb = this.getVerb();
+      var object = this.getObject();
+      var context = this.getContext();
+
+      if (
+        _.isEmpty(verb) ||
+        _.isEmpty(object) ||
+        _.isEmpty(context)
+      ) {
+        return null;
+      }
+
+      statement.verb = verb;
+      statement.object = object;
+      statement.context = context;
+
+      return statement;
     },
 
     getVerb: function() {
@@ -25,7 +44,7 @@ define(function(require) {
     getActivityDefinitionObject: function() {
       var object = StatementModel.prototype.getActivityDefinitionObject.call(this);
 
-      if (!object) {
+      if (_.isEmpty(object)) {
         object = {};
       }
 
@@ -38,7 +57,12 @@ define(function(require) {
     },
 
     getIri: function() {
-      if (!this.get('activityId') || !this.get('model') || !this.get('model').get('_type') || !this.get('model').get('_id')) {
+      if (
+        _.isEmpty(this.get('activityId')) ||
+        _.isEmpty(this.get('model')) ||
+        _.isEmpty(this.get('model').get('_type')) ||
+        _.isEmpty(this.get('model').get('_id'))
+      ) {
         return null;
       }
 
@@ -52,14 +76,15 @@ define(function(require) {
     getContextActivities: function() {
       var contextActivities = StatementModel.prototype.getContextActivities.call(this);
 
-      if (!contextActivities) {
+      if (_.isEmpty(contextActivities)) {
         contextActivities = {};
       }
 
       if (this.get('model').get('_isPartOfAssessment') == true) {
+        // component -> block -> article
         var article = this.get('model').getParent().getParent();
 
-        if (article) {
+        if (!_.isEmpty(article)) {
           var assessmentIri = [this.get('activityId'), 'assessment', article.get('_id')].join('/');
           contextActivities.parent = {
             id : assessmentIri

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -1,0 +1,160 @@
+define(function(require) {
+
+  var Adapt = require('coreJS/adapt');
+  var Backbone = require('backbone');
+
+  var ComponentStatementModel = Backbone.Model.extend({
+
+    defaults: {
+      activityId: null,
+      actor: null,
+      registration: null,
+      componentState: null
+    },
+
+    initialize: function() {
+      if (!this.get("activityId")) {
+        return null;
+      }
+
+      if (!this.get("actor")) {
+        return null;
+      }
+
+      if (!this.get("registration")) {
+        return null;
+      }
+
+      if (!this.get("componentState")) {
+        return null;
+      }
+    },
+
+    getStatementObject: function() {
+      var statement = {};
+
+      var verb = this.getVerb();
+      var object = this.getObject();
+      var context = this.getContext();
+
+      if (!verb) {
+        console.log('Failed to generate statement for assessment: Could not generate \'verb\'');
+        return null;
+      }
+
+      statement.verb = verb;
+
+      if (!this.get('actor')) {
+        console.log('Failed to generate statement for assessment: \'actor\' is missing or invalid');
+        return null;
+      }
+
+      statement.actor = this.get('actor');
+
+      if (!object || !object.id) {
+        console.log('Failed to generate statement for assessment: Could not generate \'object\'');
+        return null;
+      }
+
+      statement.object = object;
+
+      if (context) {
+        statement.context = context;
+      }
+
+      return statement;
+    },
+
+    getVerb: function() {
+      return ADL.verbs.experienced;
+    },
+
+    // The Object of a Statement can be an Activity, Agent/Group, Sub-Statement, or Statement Reference
+    getObject: function() {
+      var object = {};
+
+      var iri = this.getIri();
+      if (!iri) {
+        return null;
+      }
+
+      object.id = iri;
+
+      object.objectType = "Activity";
+
+      object.definition = this.getActivityDefinitionObject();
+
+      return object;
+    },
+
+    //@TODO - move to super
+    getActivityDefinitionObject: function() {
+      var object = {
+        name: null,
+        description: null,
+        type: null
+      };
+
+      object.name = {};
+      object.name[Adapt.config.get('_defaultLanguage')] = this.get('componentState').get('title');
+
+      object.type = this.get('componentState').get('_type');
+
+      return object;
+    },
+
+    getContext: function() {
+      var context = {};
+
+      var contextActivities = this.getContextActivities();
+
+      if (contextActivities) {
+        context.contextActivities = contextActivities;
+      }
+
+      var language = Adapt.config.get('_defaultLanguage');
+
+      if (language) {
+        context.language = language
+      }
+
+      var registration = this.get("registration");
+      if (registration) {
+        context.registration = registration
+      }
+
+      //@TODO - can do parent until...
+
+      return context;
+    },
+
+    getContextActivities: function() {
+      var contextActivities = {};
+
+      if (this.get('activityId')) {
+        contextActivities.parent = {
+          id: this.get('activityId'),
+          objectType: "Activity"
+        }
+      }
+
+      return contextActivities;
+    },
+
+    getIri: function() {
+      if (!this.get('activityId') || !this.get('_id')) {
+        return null;
+      }
+
+      return [this.get('activityId'), 'component', this.get('_id')].join('/');
+    },
+
+  });
+
+  return ComponentStatementModel;
+
+});
+
+//@TODO - if we record a statement for a component should we avoid bubbling up? or vice versa
+
+//@TODO - registration needs set when working off downloaded course - fake it?

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -2,115 +2,62 @@ define(function(require) {
 
   var Adapt = require('coreJS/adapt');
   var Backbone = require('backbone');
+  var StatementModel = require('./statement');
 
-  var ComponentStatementModel = Backbone.Model.extend({
-
-    defaults: {
-      activityId: null,
-      actor: null,
-      registration: null,
-      componentState: null
-    },
+  var ComponentStatementModel = StatementModel.extend({
 
     initialize: function() {
-      if (!this.get("activityId")) {
-        return null;
-      }
-
-      if (!this.get("actor")) {
-        return null;
-      }
-
-      if (!this.get("registration")) {
-        return null;
-      }
-
-      if (!this.get("componentState")) {
-        return null;
-      }
+      return StatementModel.prototype.initialize.call(this);
     },
 
     getStatementObject: function() {
-      var statement = {};
-
-      var verb = this.getVerb();
-      var object = this.getObject();
-      var context = this.getContext();
-
-      if (!verb) {
-        return null;
-      }
-
-      statement.verb = verb;
-
-      if (!this.get('actor')) {
-        return null;
-      }
-
-      statement.actor = this.get('actor');
-
-      if (!object || !object.id) {
-        return null;
-      }
-
-      statement.object = object;
-
-      if (context) {
-        statement.context = context;
-      }
-
-      return statement;
+      return StatementModel.prototype.getStatementObject.call(this);
     },
 
     getVerb: function() {
-      return ADL.verbs.experienced;
+      return StatementModel.prototype.getVerb.call(this);
     },
 
-    // The Object of a Statement can be an Activity, Agent/Group, Sub-Statement, or Statement Reference
     getObject: function() {
-      var object = {};
+      return StatementModel.prototype.getObject.call(this);
+    },
 
-      var iri = this.getIri(this.get('componentState'));
-      if (!iri) {
-        return null;
+    getActivityDefinitionObject: function() {
+      var object = StatementModel.prototype.getActivityDefinitionObject.call(this);
+
+      if (!object) {
+        object = {};
       }
 
-      object.id = iri;
+      object.name = {};
+      object.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
 
-      object.objectType = "Activity";
-
-      object.definition = this.getActivityDefinitionObject(this.get('componentState'));
+      object.type = ['http://adaptlearning.org', this.get('model').get('_type'), this.get('model').get('_component')].join('/');
 
       return object;
     },
 
+    getIri: function() {
+      if (!this.get('activityId') || !this.get('model') || !this.get('model').get('_type') || !this.get('model').get('_id')) {
+        return null;
+      }
+
+      return [this.get('activityId'), this.get('model').get('_type'), this.get('model').get('_id')].join('/');
+    },
+
     getContext: function() {
-      var context = {};
-
-      var contextActivities = this.getContextActivities();
-
-      if (contextActivities) {
-        context.contextActivities = contextActivities;
-      }
-
-      var language = Adapt.config.get('_defaultLanguage');
-      if (language) {
-        context.language = language
-      }
-
-      var registration = this.get("registration");
-      if (registration) {
-        context.registration = registration
-      }
-
-      return context;
+      return StatementModel.prototype.getContext.call(this);
     },
 
     getContextActivities: function() {
-      var contextActivities = {};
+      var contextActivities = StatementModel.prototype.getContextActivities.call(this);
 
-      if (this.get('componentState').get('_isPartOfAssessment') == true) {
-        var article = this.get('componentState').getParent().getParent();
+      if (!contextActivities) {
+        contextActivities = {};
+      }
+
+      if (this.get('model').get('_isPartOfAssessment') == true) {
+        var article = this.get('model').getParent().getParent();
 
         if (article) {
           var assessmentIri = [this.get('activityId'), 'assessment', article.get('_id')].join('/');
@@ -118,29 +65,9 @@ define(function(require) {
             id : assessmentIri
           }
         }
-
       }
 
       return contextActivities;
-    },
-
-    getIri: function() {
-      if (!this.get('activityId') || !this.get('componentState').get('_type') || !this.get('componentState').get('_id')) {
-        return null;
-      }
-
-      return [this.get('activityId'), this.get('componentState').get('_type'), this.get('componentState').get('_id')].join('/');
-    },
-
-    getActivityDefinitionObject: function() {
-      var object = {};
-
-      object.name = {};
-      object.name[Adapt.config.get('_defaultLanguage')] = this.get('componentState').get('title');
-
-      object.type = [this.get('componentState').get('_component'), this.get('componentState').get('_type')].join('-');
-
-      return object;
     },
 
   });

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -38,21 +38,18 @@ define(function(require) {
       var context = this.getContext();
 
       if (!verb) {
-        console.log('Failed to generate statement for assessment: Could not generate \'verb\'');
         return null;
       }
 
       statement.verb = verb;
 
       if (!this.get('actor')) {
-        console.log('Failed to generate statement for assessment: \'actor\' is missing or invalid');
         return null;
       }
 
       statement.actor = this.get('actor');
 
       if (!object || !object.id) {
-        console.log('Failed to generate statement for assessment: Could not generate \'object\'');
         return null;
       }
 
@@ -73,7 +70,7 @@ define(function(require) {
     getObject: function() {
       var object = {};
 
-      var iri = this.getIriForModel(this.get('componentState'));
+      var iri = this.getIri(this.get('componentState'));
       if (!iri) {
         return null;
       }
@@ -82,7 +79,7 @@ define(function(require) {
 
       object.objectType = "Activity";
 
-      object.definition = this.getActivityDefinitionObjectForModel(this.get('componentState'));
+      object.definition = this.getActivityDefinitionObject(this.get('componentState'));
 
       return object;
     },
@@ -116,7 +113,7 @@ define(function(require) {
         var article = this.get('componentState').getParent().getParent();
 
         if (article) {
-          var assessmentIri = [this.get('activityId'), 'assessment', this.get('assessmentState').id].join('/');
+          var assessmentIri = [this.get('activityId'), 'assessment', article.get('_id')].join('/');
           contextActivities.parent = {
             id : assessmentIri
           }
@@ -127,21 +124,21 @@ define(function(require) {
       return contextActivities;
     },
 
-    getIriForModel: function(model) {
-      if (!this.get('activityId') || !model.get('_type') || !model.get('_id')) {
+    getIri: function() {
+      if (!this.get('activityId') || !this.get('componentState').get('_type') || !this.get('componentState').get('_id')) {
         return null;
       }
 
-      return [this.get('activityId'), model.get('_type'), model.get('_id')].join('/');
+      return [this.get('activityId'), this.get('componentState').get('_type'), this.get('componentState').get('_id')].join('/');
     },
 
-    getActivityDefinitionObjectForModel: function(model) {
+    getActivityDefinitionObject: function() {
       var object = {};
 
       object.name = {};
-      object.name[Adapt.config.get('_defaultLanguage')] = model.get('title');
+      object.name[Adapt.config.get('_defaultLanguage')] = this.get('componentState').get('title');
 
-      object.type = model.get('_type');
+      object.type = [this.get('componentState').get('_component'), this.get('componentState').get('_type')].join('-');
 
       return object;
     },

--- a/js/models/statement.js
+++ b/js/models/statement.js
@@ -1,0 +1,134 @@
+define(function(require) {
+
+  var Adapt = require('coreJS/adapt');
+  var Backbone = require('backbone');
+
+  var StatementModel = Backbone.Model.extend({
+
+    defaults: {
+      activityId: null,
+      actor: null,
+      registration: null,
+      model: null,
+    },
+
+    initialize: function() {
+      if (!this.get("activityId")) {
+        return null;
+      }
+
+      if (!this.get("actor")) {
+        return null;
+      }
+
+      if (!this.get("registration")) {
+        return null;
+      }
+
+      if (!this.get("model")) {
+        return null;
+      }
+    },
+
+    getStatementObject: function() {
+      var statement = {};
+
+      var verb = this.getVerb();
+      var object = this.getObject();
+      var context = this.getContext();
+
+      if (!verb) {
+        return null;
+      }
+
+      statement.verb = verb;
+
+      if (!this.get('actor')) {
+        return null;
+      }
+
+      statement.actor = this.get('actor');
+
+      if (!object || !object.id) {
+        return null;
+      }
+
+      statement.object = object;
+
+      if (context) {
+        statement.context = context;
+      }
+
+      return statement;
+    },
+
+    getVerb: function() {
+      return ADL.verbs.experienced;
+    },
+
+    getObject: function() {
+      var object = {};
+
+      var iri = this.getIri();
+      if (!iri) {
+        return null;
+      }
+
+      object.id = iri;
+
+      object.objectType = "Activity";
+
+      object.definition = this.getActivityDefinitionObject(this.get('model'));
+
+      return object;
+    },
+
+    getActivityDefinitionObject: function() {
+      var object = {};
+
+      object.name = {};
+      object.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
+
+      object.type = this.get('model').get('_type');
+
+      return object;
+    },
+
+    getContext: function() {
+      var context = {};
+
+      var contextActivities = this.getContextActivities();
+      if (contextActivities) {
+        context.contextActivities = contextActivities;
+      }
+
+      var language = Adapt.config.get('_defaultLanguage');
+      if (language) {
+        context.language = language
+      }
+
+      var registration = this.get("registration");
+      if (registration) {
+        context.registration = registration
+      }
+
+      return context;
+    },
+
+    getContextActivities: function() {
+      return {};
+    },
+
+    getIri: function() {
+      if (!this.get('activityId') || !this.get('model').get('_type') || this.get('model').get('_id')) {
+        return null;
+      }
+
+      return [this.get('activityId'), this.get('model').get('_type'), this.get('model').get('_id')].join('/');
+    },
+
+  });
+
+  return StatementModel;
+
+});

--- a/js/models/statement.js
+++ b/js/models/statement.js
@@ -1,6 +1,7 @@
 define(function(require) {
 
   var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
   var Backbone = require('backbone');
 
   var StatementModel = Backbone.Model.extend({

--- a/required/offline_xapi_wrapper.js
+++ b/required/offline_xapi_wrapper.js
@@ -3,6 +3,7 @@ var xapiWrapper = {
     actor: "{\"objectType\": \"Agent\",\"account\": {\"homePage\": \"http://www.example.com\",\"name\": \"1625378\"}}",
     activity_id: "http://www.example.com/LA1/001/intro",
     endpoint: "http://lrs.example.com/lrslistener/",
+    registration: "760e3480-ba55-4991-94b0-01820dbd23a2"
   },
 
   getState: function(activityid, agent, stateid, registration, since, callback) {
@@ -10,23 +11,8 @@ var xapiWrapper = {
   },
 
   sendStatement: function(stmt, callback) {
-    var a = stmt.actor.account.name;
-    var v = stmt.verb.display["en-US"];
-    var o = stmt.object.id;
-    var r = stmt.result;
-
-    var message = "xAPI statement sent: " + a + " " + v + " " + o;
-
-    if (r && r.score) {
-      if (r.score.scaled) {
-        message += " with a scaled score of " + r.score.scaled;
-      } else if (r.score.raw) {
-        message += " with a raw score of " + r.score.raw;
-      }
-    }
-
-    console.log(message);
-
+    console.log("xAPI statement sent:");
+    console.log(JSON.stringify(stmt));
     return true;
   },
 


### PR DESCRIPTION
Implemented generic statements for components (below is an example of the statement sent for a text component)

{
	"verb": {
		"id": "http://adlnet.gov/expapi/verbs/experienced",
		"display": {
			"de-DE": "erlebte",
			"en-US": "experienced",
			"fr-FR": "a éprouvé",
			"es-ES": "experimentó"
		}
	},
	"actor": {
		"objectType": "Agent",
		"account": {
			"homePage": "http://www.example.com",
			"name": "1625378"
		}
	},
	"object": {
		"id": "http://www.example.com/LA1/001/intro/component/56d6e8de211b207b14611e1a",
		"objectType": "Activity",
		"definition": {
			"name": {
				"en": "TEXT"
			},
			"type": "http://adaptlearning.org/component/text"
		}
	},
	"context": {
		"contextActivities": {
			"parent": {
				"id": "http://www.example.com/LA1/001/intro/assessment/56c303be8a8c5efe4704ccae"
			}
		},
		"language": "en",
		"registration": "760e3480-ba55-4991-94b0-01820dbd23a2"
	}
}

Implemented a 'StatementModel' base class and modified component and assessment statement models to extend this