### PR TITLE
Prefer the locally provided ActivityId

### DIFF
--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -51,7 +51,8 @@ define(function(require) {
       if (!this.validateParams()) {
         return;
       }
-
+      // We need to listen for stateLoad before we load state.
+      this.listenTo(Adapt, "xapi:stateLoaded", this.restoreState);
       this.loadState();
       this.set('initialised', true);
 
@@ -76,7 +77,6 @@ define(function(require) {
       this.listenTo(Adapt, "assessments:complete", this.onAssessmentComplete);
       this.listenTo(Adapt, "assessment:complete", this.onAllAssessmentsComplete);
       this.listenTo(Adapt, "xapi:stateChanged", this.onStateChanged);
-      this.listenTo(Adapt, "xapi:stateLoaded", this.restoreState);
     },
 
     onBlockComplete: function(block) {

--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -44,7 +44,8 @@ define(function(require) {
 
       this.set('actor', this.getLRSAttribute('actor'));
 
-      this.set('activityId', this.getLRSAttribute('activity_id'));
+      this.set('activityId', (this.getConfig('_activityID')) ?
+        this.getConfig('_activityID') : this.getLRSAttribute('activity_id'));
       this.set('registration', this.getLRSAttribute('registration'));
 
       if (!this.validateParams()) {


### PR DESCRIPTION
We've swithered about this back and forth, but the LMS plugin we're
testing against doesn't pass the activityID in the url so we should look
for a local value first.